### PR TITLE
Fix E2E issues #24–#31; update to Bee 2.8 / bee-js 12.x / swarm-cli 3.x

### DIFF
--- a/.claude/skills/act/SKILL.md
+++ b/.claude/skills/act/SKILL.md
@@ -139,7 +139,10 @@ const result = await bee.uploadFile(batchId, 'Secret data', 'secret.txt', {
 })
 
 console.log('Encrypted reference:', result.reference.toHex())
-console.log('History address:', result.historyAddress.toHex())
+
+// historyAddress is an Optional<Reference> in bee-js 12.x — unwrap it before use.
+const historyRef = result.historyAddress.getOrThrow()   // or: result.historyAddress.value
+console.log('History address:', historyRef.toHex())
 // WARNING: Save both — losing the history address means permanent loss of access to encrypted data
 ```
 
@@ -150,14 +153,20 @@ import { Bee } from '@ethersphere/bee-js'
 
 const bee = new Bee('http://localhost:1633')
 
+// The publisher key is the uploader's public key — get it as a PublicKey object and
+// pass it directly (do not stringify it). historyRef is the unwrapped Reference from upload.
+const { publicKey } = await bee.getNodeAddresses()
+
 const file = await bee.downloadFile(reference, 'secret.txt', {
-  actHistoryAddress: historyAddress,
-  actPublisher: publisherPublicKey
+  actHistoryAddress: historyRef,   // Reference (unwrapped from result.historyAddress)
+  actPublisher: publicKey          // PublicKey object from getNodeAddresses()
 })
 
 console.log('Decrypted:', file.data.toUtf8())
 // Without ACT parameters, this returns "not found"
 ```
+
+> **swarm-cli quirk:** in testing, `swarm-cli download <ref> --act --act-history-address <hist> --act-publisher <pk>` can return 404 even with correct values, while the equivalent Bee HTTP API call (same headers) returns 200. If the CLI download fails, retry via the API or bee-js.
 
 ### Manage grantees
 

--- a/.claude/skills/feed/SKILL.md
+++ b/.claude/skills/feed/SKILL.md
@@ -131,8 +131,10 @@ await writer.uploadReference(batchId, newUpload.reference);
 ### Create identity (first time only)
 
 ```bash
-swarm-cli identity create publisher
+swarm-cli identity create publisher --password <SECURE_PASSWORD>
 ```
+
+`identity create` builds a password-protected V3 wallet and **prompts interactively for a password** if you omit `--password` — which blocks non-interactive/agent runs, so always pass `--password`. (Use `--only-keypair` instead for a fast, cleartext keypair with no password.)
 
 Save output securely. Export later with: `swarm-cli identity export publisher`
 
@@ -163,8 +165,11 @@ swarm-cli feed upload ./updated-content \
 ```bash
 swarm-cli feed print \
   --identity publisher \
-  --topic-string my-topic
+  --topic-string my-topic \
+  --password <SECURE_PASSWORD>
 ```
+
+`--password` is required here too when the identity is a password-protected V3 wallet — without it the command prompts interactively and stalls agent runs.
 
 ## Use Cases
 

--- a/.claude/skills/host-website/SKILL.md
+++ b/.claude/skills/host-website/SKILL.md
@@ -58,8 +58,10 @@ Access at: `http://localhost:1633/bzz/<SWARM_HASH>/`
 #### Step 1: Create publisher identity (first time only)
 
 ```bash
-swarm-cli identity create website-publisher
+swarm-cli identity create website-publisher --password <SECURE_PASSWORD>
 ```
+
+Always pass `--password` — without it, `identity create` prompts interactively for a V3 wallet password and blocks non-interactive/agent runs. (Use `--only-keypair` for a fast, cleartext keypair with no password.) The same `--password` is needed later for `swarm-cli feed print` with this identity.
 
 Save the output securely. To export later: `swarm-cli identity export website-publisher`
 

--- a/.claude/skills/messaging/SKILL.md
+++ b/.claude/skills/messaging/SKILL.md
@@ -72,6 +72,7 @@ const subscription = bee.gsocSubscribe(
   {
     onMessage: message => console.log('Received:', message.toJSON()),
     onError: err => console.error('Error:', err),
+    onClose: () => console.log('Subscription closed'),
   }
 )
 
@@ -121,10 +122,13 @@ import { Bee, Topic } from '@ethersphere/bee-js'
 const bee = new Bee('http://localhost:1633')
 const topic = Topic.fromString('my-topic')
 
-// Continuous subscription
+// Continuous subscription.
+// All three handlers are required in bee-js 12.x — omitting onClose throws
+// "Expected function for onClose, got: undefined".
 bee.pssSubscribe(topic, {
   onMessage: msg => console.log('Received:', msg.toUtf8()),
   onError: err => console.error('Error:', err.message),
+  onClose: () => console.log('Subscription closed'),
 })
 ```
 

--- a/.claude/skills/setup-bee/SKILL.md
+++ b/.claude/skills/setup-bee/SKILL.md
@@ -96,7 +96,7 @@ Install swarm-cli (v3.x, which bundles bee-js 12.x):
 npm install -g @ethersphere/swarm-cli
 ```
 
-> **Version note:** This guide targets Bee **2.8.0**, swarm-cli **3.x**, and bee-js **12.x**. bee-js 12.x lists Bee **2.7.0** as its officially supported version, so connecting it to a 2.8.0 node prints a non-fatal version-mismatch warning. It works — you can ignore the warning, or run Bee 2.7.1 if you want the warning gone.
+> **Version note:** This guide targets Bee **2.8.0**, swarm-cli **3.x**, and bee-js **12.x**. bee-js 12.x is officially tested against Bee **2.7.0**, so `bee.isSupportedExactVersion()` returns `false` against a 2.8.0 node — but that's only a version-*string* difference. bee-js does **not** print any warning, and `bee.isSupportedApiVersion()` returns `true` (the HTTP API is compatible), so everything works normally. Use `bee.getVersions()` to inspect the exact numbers; run Bee 2.7.x only if you specifically need an exact-version match.
 
 ## Step 2: Start in Ultra-Light Mode
 

--- a/.claude/skills/setup-bee/SKILL.md
+++ b/.claude/skills/setup-bee/SKILL.md
@@ -42,7 +42,36 @@ Use this tag in the install command below (replace TAG value).
 - curl or wget
 - ~0.01 xDAI + ~0.2 xBZZ on Gnosis Chain (for upgrading to light node)
 
+## Step 0: Install System Prerequisites
+
+A fresh machine usually has none of `curl`, `node`, or `npm`. Check first, then install only what's missing:
+
+```bash
+curl --version; node --version; npm --version
+```
+
+**Ubuntu / Debian:**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y curl
+# Node.js 20 (recommended) via NodeSource:
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+# (or, for the distro's older Node 18 + npm: sudo apt-get install -y nodejs npm)
+```
+
+**macOS (Homebrew):**
+
+```bash
+brew install curl node
+```
+
+Re-run the check above and confirm `node --version` is v18 or higher before continuing.
+
 ## Step 1: Install Bee
+
+The latest Bee release is **v2.8.0**. Fetch the current tag (see "Before Starting") or use it directly:
 
 ```bash
 curl -s https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | TAG=<LATEST_TAG> bash
@@ -54,13 +83,20 @@ Or with wget:
 wget -q -O - https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | TAG=<LATEST_TAG> bash
 ```
 
+> **Non-root Linux users:** the script installs to system paths and fails with "Failed to install bee" without root. Run it through `sudo` while preserving the `TAG` variable:
+> ```bash
+> curl -s https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | sudo env TAG=<LATEST_TAG> bash
+> ```
+
 Verify: `bee version`
 
-Install swarm-cli:
+Install swarm-cli (v3.x, which bundles bee-js 12.x):
 
 ```bash
 npm install -g @ethersphere/swarm-cli
 ```
+
+> **Version note:** This guide targets Bee **2.8.0**, swarm-cli **3.x**, and bee-js **12.x**. bee-js 12.x lists Bee **2.7.0** as its officially supported version, so connecting it to a 2.8.0 node prints a non-fatal version-mismatch warning. It works — you can ignore the warning, or run Bee 2.7.1 if you want the warning gone.
 
 ## Step 2: Start in Ultra-Light Mode
 
@@ -77,6 +113,8 @@ Verify it's running:
 ```bash
 curl -s http://localhost:1633/status | jq
 ```
+
+> **Note:** Right after `bee start`, the API may return HTTP **503 "Node is syncing"** for up to ~30 seconds while it initializes. This is normal — wait and retry; it does not mean the node failed.
 
 ## Step 3: Fund Your Node
 
@@ -101,6 +139,11 @@ swarm-cli utility redeem <GIFT_CODE_PRIVATE_KEY>
 ```
 
 This transfers xBZZ and xDAI from the gift wallet to the Bee node wallet automatically. The node's wallet address is detected from the running Bee node.
+
+> **If redeem fails with "Upstream error: 429"**, the default RPC is rate-limited. Point swarm-cli at a different Gnosis RPC:
+> ```bash
+> swarm-cli utility redeem <GIFT_CODE_PRIVATE_KEY> --json-rpc-url https://rpc.gnosischain.com
+> ```
 
 To redeem to a specific wallet instead:
 
@@ -128,43 +171,71 @@ bee start \
   --blockchain-rpc-endpoint https://xdai.fairdatasociety.org
 ```
 
+> **If the node shuts down immediately with "Upstream error: 429"**, the default RPC (`xdai.fairdatasociety.org`) is rate-limited and Bee does not retry — it exits on the first 429. Restart with a fallback endpoint:
+> ```bash
+> bee start ... --blockchain-rpc-endpoint https://rpc.gnosischain.com
+> ```
+> The FDS endpoint is an archive node (better for initial batch-data sync), so prefer it when it's reachable and only fall back to `rpc.gnosischain.com` when you hit 429s.
+
 The node deploys a chequebook and syncs chain data (~5 minutes). Monitor:
 
 ```bash
 swarm-cli status
 ```
 
-When "Chainsync" shows synchronized, your node is ready.
+`swarm-cli status` does **not** print the word "synchronized" — instead the Chainsync section shows the current vs. latest block and their gap:
+
+```
+Chainsync
+Block: 45,299,125 / 45,299,131 (Δ 6)
+```
+
+When the gap (**Δ**) is small — roughly **Δ < 10** — the node is caught up and ready.
 
 ## Step 5: Buy a Postage Stamp
 
-Required before any upload.
+Required before any upload. **Depth** sets capacity, **amount** sets duration.
+
+> **Budget check first.** Cost in xBZZ ≈ `amount × 2^depth ÷ 10^16`. A depth-22, 3-month stamp costs **~4.2 xBZZ** — but a standard gift code only provides **~0.5 xBZZ**, so the old `--depth 22` suggestion fails with "You do not have enough BZZ". With a single gift code you can realistically only afford a small (depth-17, ~40 KB) stamp. Buy what your balance covers, or fund more xBZZ first (see Step 3).
+
+### Compute the amount from the live price
+
+The amount-per-day depends on the current network storage price, so don't hardcode it — read it live:
 
 ```bash
-swarm-cli stamp buy --depth 22 --amount 120159417615
+PRICE=$(curl -s http://localhost:1633/chainstate | jq .currentPrice)
+# amount = currentPrice * 17280 (blocks/day) * desired_days
+echo $((PRICE * 17280 * 30))   # ≈ amount for 30 days
+```
+
+### Budget-friendly stamp (fits a ~0.5 xBZZ gift code)
+
+```bash
+swarm-cli stamp buy --depth 17 --amount 9345732487    # ~40 KB, ~1 week, ~0.12 xBZZ
 ```
 
 Or via API:
 
 ```bash
-curl -X POST http://localhost:1633/stamps/120159417615/22
+curl -X POST http://localhost:1633/stamps/9345732487/17
 ```
 
 Save the **Stamp ID** returned.
 
 ### Stamp sizing
 
-These are **effective (realistic) capacities** — not theoretical maximums:
+These are **effective (realistic) capacities** — not theoretical maximums (verify with `Utils.getStampEffectiveBytes(depth)` in bee-js 12.x):
 
-| Depth | Effective capacity | | Duration | Amount |
+| Depth | Effective capacity | | Duration | Amount (approx, varies with price) |
 |-------|-------------------|-|----------|--------|
-| 17 | ~7 MB | | 1 day | 1335104641 |
-| 19 | ~110 MB | | 1 week | 9345732487 |
-| 20 | ~680 MB | | 1 month | 40053139205 |
-| 21 | ~2.6 GB | | 3 months | 120159417615 |
-| 22 | ~7.7 GB | | 1 year | 480637670460 |
+| 17 | ~40 KB | | 1 week | ~9,345,732,487 |
+| 18 | ~6 MB | | 1 month | ~40,053,139,205 |
+| 19 | ~110 MB | | 3 months | ~120,159,417,615 |
+| 20 | ~680 MB | | 6 months | ~240,318,835,230 |
+| 21 | ~2.6 GB | | 1 year | ~480,637,670,460 |
+| 22 | ~7.7 GB | | | |
 
-Formula: `amount = 1335104641 * desired_days`. For capacity, see `/stamps` for the full sizing guide.
+The amounts above are upper-bound estimates from a higher historical price and can overpay by ~40%. Always compute from the live `currentPrice` (above). For the full sizing/cost guide, see `/stamps`.
 
 ### Manage stamps later
 

--- a/.claude/skills/setup-bee/SKILL.md
+++ b/.claude/skills/setup-bee/SKILL.md
@@ -96,7 +96,7 @@ Install swarm-cli (v3.x, which bundles bee-js 12.x):
 npm install -g @ethersphere/swarm-cli
 ```
 
-> **Version note:** This guide targets Bee **2.8.0**, swarm-cli **3.x**, and bee-js **12.x**. bee-js 12.x is officially tested against Bee **2.7.0**, so `bee.isSupportedExactVersion()` returns `false` against a 2.8.0 node — but that's only a version-*string* difference. bee-js does **not** print any warning, and `bee.isSupportedApiVersion()` returns `true` (the HTTP API is compatible), so everything works normally. Use `bee.getVersions()` to inspect the exact numbers; run Bee 2.7.x only if you specifically need an exact-version match.
+> **Version note:** Run the latest Bee — **2.8.x**. 2.8 was a breaking change, so **do not run 2.7.x**. This guide targets Bee **2.8.0**, swarm-cli **3.x**, and bee-js **12.x**. bee-js 12.x hasn't yet bumped its tested-version constant past Bee **2.7.0**, so `bee.isSupportedExactVersion()` returns `false` against a 2.8.0 node — that's a cosmetic version-*string* lag in bee-js, not a real incompatibility. bee-js prints **no** warning, and `bee.isSupportedApiVersion()` returns `true` (the HTTP API is compatible), so everything works normally. Inspect the exact numbers with `bee.getVersions()` if needed.
 
 ## Step 2: Start in Ultra-Light Mode
 

--- a/.claude/skills/stamps/SKILL.md
+++ b/.claude/skills/stamps/SKILL.md
@@ -48,12 +48,18 @@ These are **effective (realistic) capacities** — not theoretical maximums. Act
 
 ### Size options
 
+Effective capacities (verify with `Utils.getStampEffectiveBytes(depth)`):
+
 | Size | Depth |
 |------|-------|
+| ~40 KB | 17 |
+| ~6 MB | 18 |
 | 110 MB | 19 |
 | 680 MB | 20 |
 | 2.6 GB | 21 |
 | 7.7 GB | 22 |
+
+> **Low depths are tiny:** depth 17 holds only ~40 KB (not ~7 MB — that figure is actually depth 18). Below depth 19, effective capacity is a small fraction of the `2^depth × 4KB` theoretical size because chunks spread unevenly across 2^16 buckets.
 
 ### Duration options
 
@@ -75,17 +81,22 @@ amount = currentPrice * 17280 * days
 
 Where `17280` = blocks per day (5-second blocks on Gnosis Chain).
 
-**Quick reference** (approximate, varies with network price):
+**Quick reference** — these are **upper-bound estimates** based on a higher historical price (~77,261 PLUR/chunk/block) and can overpay by ~40% versus the current price. Treat them as ceilings and always compute from the live `currentPrice` above:
 
-| Duration | Amount (approximate) |
+| Duration | Amount (upper-bound estimate) |
 |----------|---------------------|
-| 15 days | 20,026,569,615 |
-| 1 month | 40,053,139,205 |
-| 3 months | 120,159,417,615 |
-| 6 months | 240,318,835,230 |
-| 1 year | 480,637,670,460 |
+| 15 days | ~20,026,569,615 |
+| 1 month | ~40,053,139,205 |
+| 3 months | ~120,159,417,615 |
+| 6 months | ~240,318,835,230 |
+| 1 year | ~480,637,670,460 |
 
-Formula shortcut: `amount ≈ 1,335,104,641 * desired_days`
+To compute the actual amount from the live price:
+
+```bash
+PRICE=$(curl -s http://localhost:1633/chainstate | jq .currentPrice)
+echo $((PRICE * 17280 * 30))   # amount for 30 days
+```
 
 **Minimum amount** must cover 24 hours of storage.
 
@@ -100,7 +111,7 @@ Formula shortcut: `amount ≈ 1,335,104,641 * desired_days`
    curl -s http://localhost:1633/wallet | jq '{bzzBalance, nativeTokenBalance}'
    ```
 
-2. Calculate cost using bee-js utility or this formula:
+2. Calculate cost with `Utils.getStampCost(depth, amount)` (returns a BZZ object), or this formula:
    ```
    cost in PLUR = amount * (2 ^ depth)
    cost in BZZ  = cost in PLUR / 10^16
@@ -158,17 +169,21 @@ const batchId = await bee.createPostageBatch('120159417615', 22)
 
 ## bee-js Utility Functions
 
+All stamp helpers live under the `Utils` namespace in bee-js 12.x — they are **not** top-level exports. (Several were renamed from earlier versions; the old names below no longer exist.)
+
 ```javascript
-import {
-  getDepthForCapacity,          // bytes → depth
-  getAmountForTtl,              // seconds → amount
-  getStampCost,                 // depth + amount → cost in BZZ
-  getStampTtlSeconds,           // amount → TTL in seconds
-  getStampUsage,                // check how full a stamp is
-  getStampEffectiveBytes,       // depth → effective storable bytes
-  getStampMaximumCapacityBytes  // depth → max theoretical bytes
-} from '@ethersphere/bee-js'
+import { Utils, Size, Duration } from '@ethersphere/bee-js'
+
+Utils.getDepthForSize(Size.fromMegabytes(100))        // Size → minimum depth (was getDepthForCapacity)
+Utils.getStampEffectiveBytes(depth)                   // depth → effective storable bytes
+Utils.getStampTheoreticalBytes(depth)                 // depth → max theoretical bytes (was getStampMaximumCapacityBytes)
+Utils.getStampCost(depth, amount)                     // depth + amount → cost (BZZ object)
+Utils.getStampUsage(utilization, depth, bucketDepth)  // how full a stamp is
+Utils.getStampDuration(amount, pricePerBlock, blockTime)   // amount → Duration (was getStampTtlSeconds)
+Utils.getAmountForDuration(Duration.fromDays(30), pricePerBlock, blockTime)  // Duration → amount (was getAmountForTtl)
 ```
+
+`pricePerBlock` is the network's `currentPrice` (from `GET /chainstate`); `blockTime` is `5` seconds on Gnosis Chain.
 
 ## Manage Stamps
 

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -68,9 +68,10 @@ If connected peers = 0:
 swarm-cli status
 ```
 
-Watch the "Chainsync" section. If blocks remaining is high, the node is still syncing (~5 minutes typical).
+Watch the "Chainsync" section. It shows current vs. latest block and a gap, e.g. `Block: 45,299,125 / 45,299,131 (Δ 6)` — it never prints "synchronized". A small gap (roughly **Δ < 10**) means the node is caught up. A large/growing gap means it's still syncing (~5 minutes typical) or stuck.
 
 If chain sync is stuck:
+- **RPC rate-limited (429):** the default `https://xdai.fairdatasociety.org` can return HTTP 429 "Too Many Requests"; Bee does not retry and exits on the first 429 at startup. Restart with a fallback: `bee start ... --blockchain-rpc-endpoint https://rpc.gnosischain.com`. For swarm-cli commands, add `--json-rpc-url https://rpc.gnosischain.com`.
 - Check the RPC endpoint is reachable: `curl -s https://xdai.fairdatasociety.org`
 - Try an alternative RPC: `https://rpc.gnosischain.com` or `https://gnosis-rpc.publicnode.com`
 
@@ -192,14 +193,17 @@ swarm-cli status
 
 ## Common Bee API Error Codes
 
+Observed on Bee 2.7.x–2.8.x:
+
 | Code | Meaning | Fix |
 |------|---------|-----|
-| 400 | Bad request (malformed input) | Check request format against API docs |
-| 402 | No usable stamp / insufficient postage | Buy or top up a stamp → `/stamps` |
-| 404 | Content not found | Content may have expired, reference is wrong, or ACT flags missing |
+| 400 | Bad request / missing required header (e.g. no `swarm-postage-batch-id`) → "invalid header params: want required" | Include and correctly format the stamp header and other required params |
+| 404 | Content not found **or** stamp batch not found ("batch with id not found") | Content expired, wrong reference, missing ACT flags, **or** an invalid/unknown stamp ID |
 | 422 | Unprocessable entity | Check parameter types (e.g., batch ID format) |
 | 500 | Internal server error | Check Bee logs, restart node |
-| 503 | Node not ready (still syncing) | Wait for chain sync to complete |
+| 503 | Node not ready (still syncing) | Wait for chain sync to complete (up to ~30s right after start) |
+
+> **Note:** A missing/insufficient stamp does **not** return 402 in current Bee — a missing stamp header returns **400** and an invalid stamp ID returns **404**. (402 may appear on older Bee versions or specific scenarios; treat stamp problems as 400/404.)
 
 ## Security Reminder
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is the **swarm-skills** repo — AI-powered interactive guides that help developers build on the Swarm decentralized storage network. Currently packaged as Claude Code skills, with support for other AI coding tools (Cursor, GitHub Copilot, Windsurf, Codex) planned. There is no application code, no build system, and no tests. The repo contains only skill definitions (markdown files).
+This is the **swarm-skills** repo — AI-powered interactive guides that help developers build on the Swarm decentralized storage network. Currently packaged as Claude Code skills, with support for other AI coding tools (Cursor, GitHub Copilot, Windsurf, Codex) planned. There is no application code or build system. The repo is almost entirely skill definitions (markdown files); the one exception is `scripts/verify-beejs.mjs`, which asserts the bee-js / Bee API facts the skills depend on.
+
+### Verifying skills against the latest bee-js
+
+After bumping the documented bee-js version (or to catch upstream API drift), run:
+
+```bash
+npm i @ethersphere/bee-js@12 && node scripts/verify-beejs.mjs
+```
+
+It exits non-zero if any documented fact (Utils helper names, capacity numbers, ACT/messaging types) no longer holds.
 
 ## Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Skills live in `.claude/skills/`. Each skill is a directory containing a `SKILL.
 - Code examples should cover both **bee-js** and **swarm-cli** where applicable.
 - Keep commands and code up to date with the latest Bee and bee-js versions.
 - Skills last verified against: **Bee 2.8.0**, **bee-js 12.x**, **swarm-cli 3.x**
-- Note: bee-js 12.x declares Bee **2.7.0** as its supported version, so pairing it with a Bee 2.8.0 node prints a non-fatal version-mismatch warning. All stamp helpers (`getStampCost`, `getStampEffectiveBytes`, `getDepthForSize`, `getAmountForDuration`, `getStampDuration`, `getStampTheoreticalBytes`, `getStampUsage`) live under the `Utils` namespace, not as top-level exports.
+- Note: bee-js 12.x is tested against Bee **2.7.0**, so `bee.isSupportedExactVersion()` returns `false` against a 2.8.0 node. This is only a version-string difference — bee-js prints no warning and `bee.isSupportedApiVersion()` returns `true` (HTTP API compatible), so it works normally. Verified live against Bee 2.8.0 / API 7.4.1. All stamp helpers (`getStampCost`, `getStampEffectiveBytes`, `getDepthForSize`, `getAmountForDuration`, `getStampDuration`, `getStampTheoreticalBytes`, `getStampUsage`) live under the `Utils` namespace, not as top-level exports.
 
 ## Swarm Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Skills live in `.claude/skills/`. Each skill is a directory containing a `SKILL.
 - Code examples should cover both **bee-js** and **swarm-cli** where applicable.
 - Keep commands and code up to date with the latest Bee and bee-js versions.
 - Skills last verified against: **Bee 2.8.0**, **bee-js 12.x**, **swarm-cli 3.x**
-- Note: bee-js 12.x is tested against Bee **2.7.0**, so `bee.isSupportedExactVersion()` returns `false` against a 2.8.0 node. This is only a version-string difference — bee-js prints no warning and `bee.isSupportedApiVersion()` returns `true` (HTTP API compatible), so it works normally. Verified live against Bee 2.8.0 / API 7.4.1. All stamp helpers (`getStampCost`, `getStampEffectiveBytes`, `getDepthForSize`, `getAmountForDuration`, `getStampDuration`, `getStampTheoreticalBytes`, `getStampUsage`) live under the `Utils` namespace, not as top-level exports.
+- Note: run the latest Bee (**2.8.x**) — 2.8 was a breaking change, **do not downgrade to 2.7.x**. bee-js 12.x hasn't yet bumped its tested-version constant past Bee 2.7.0, so `bee.isSupportedExactVersion()` returns `false` against a 2.8.0 node — a cosmetic version-string lag in bee-js, not a real incompatibility. bee-js prints no warning and `bee.isSupportedApiVersion()` returns `true` (HTTP API compatible), so it works normally. Verified live against Bee 2.8.0 / API 7.4.1. All stamp helpers (`getStampCost`, `getStampEffectiveBytes`, `getDepthForSize`, `getAmountForDuration`, `getStampDuration`, `getStampTheoreticalBytes`, `getStampUsage`) live under the `Utils` namespace, not as top-level exports.
 
 ## Swarm Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ Skills live in `.claude/skills/`. Each skill is a directory containing a `SKILL.
 - When referencing other skills, use the `/skill-name` format.
 - Code examples should cover both **bee-js** and **swarm-cli** where applicable.
 - Keep commands and code up to date with the latest Bee and bee-js versions.
-- Skills last verified against: **bee-js 8.x**, **swarm-cli 2.x**, **Bee 2.x**
+- Skills last verified against: **Bee 2.8.0**, **bee-js 12.x**, **swarm-cli 3.x**
+- Note: bee-js 12.x declares Bee **2.7.0** as its supported version, so pairing it with a Bee 2.8.0 node prints a non-fatal version-mismatch warning. All stamp helpers (`getStampCost`, `getStampEffectiveBytes`, `getDepthForSize`, `getAmountForDuration`, `getStampDuration`, `getStampTheoreticalBytes`, `getStampUsage`) live under the `Utils` namespace, not as top-level exports.
 
 ## Swarm Quick Reference
 

--- a/scripts/verify-beejs.mjs
+++ b/scripts/verify-beejs.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Verifies the bee-js / Bee API facts the swarm-skills rely on (issues #25/#26/#27/#28
+// and the version notes in setup-bee + CLAUDE.md). Asserts the API *surface*, not a live
+// node — re-run after any bee-js bump to catch drift (renamed Utils helpers, changed
+// types, capacity changes) before it lands in the skills.
+//
+// Usage (from the repo root):
+//   npm i @ethersphere/bee-js@12
+//   node scripts/verify-beejs.mjs
+//
+// Exits 0 if every check passes, 1 otherwise.
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import * as B from '@ethersphere/bee-js'
+
+// Resolve the installed bee-js package dir (cwd-independent) so we can read its
+// package.json and bundled type declarations.
+const entry = fileURLToPath(import.meta.resolve('@ethersphere/bee-js'))
+const marker = join('node_modules', '@ethersphere', 'bee-js')
+const PKG = entry.slice(0, entry.indexOf(marker) + marker.length)
+
+let pass = 0, fail = 0
+const ok = (name, cond, detail = '') => {
+  console.log(`${cond ? '✅ PASS' : '❌ FAIL'}  ${name}${detail ? `  — ${detail}` : ''}`)
+  cond ? pass++ : fail++
+}
+const mb = n => (n / 1e6).toFixed(2) + ' MB'
+
+const ver = JSON.parse(readFileSync(join(PKG, 'package.json'), 'utf8')).version
+console.log(`\n# bee-js ${ver}\n`)
+
+// --- versions / warning note (CLAUDE.md, setup-bee) ---
+ok('bee-js is 12.x', /^12\./.test(ver), ver)
+ok('SUPPORTED_BEE_VERSION is 2.7.x (=> 2.8.0 warning is expected)', B.SUPPORTED_BEE_VERSION.startsWith('2.7'), B.SUPPORTED_BEE_VERSION)
+
+// --- #26: stamp helpers live under Utils with the 12.x names ---
+const utilsExpected = ['getDepthForSize', 'getStampEffectiveBytes', 'getStampTheoreticalBytes', 'getStampCost', 'getStampUsage', 'getStampDuration', 'getAmountForDuration']
+for (const fn of utilsExpected) ok(`Utils.${fn} exists`, typeof B.Utils?.[fn] === 'function')
+// the pre-12.x names must be gone entirely (top-level AND under Utils)
+const goneNames = ['getDepthForCapacity', 'getAmountForTtl', 'getStampTtlSeconds', 'getStampMaximumCapacityBytes']
+for (const fn of goneNames) ok(`old name '${fn}' is absent`, B[fn] === undefined && B.Utils?.[fn] === undefined)
+ok('stamp helpers are NOT top-level exports', B.getStampCost === undefined && B.getStampEffectiveBytes === undefined)
+
+// --- #25: capacity numbers ---
+const d17 = B.Utils.getStampEffectiveBytes(17)
+const d18 = B.Utils.getStampEffectiveBytes(18)
+ok('getStampEffectiveBytes(17) ~ 40 KB (NOT ~7 MB)', d17 > 30_000 && d17 < 50_000, `${d17} bytes`)
+ok('getStampEffectiveBytes(18) ~ 6 MB (the old "7 MB" was depth 18)', d18 > 5e6 && d18 < 7.5e6, mb(d18))
+const caps = [17, 18, 19, 20, 21, 22].map(d => B.Utils.getStampEffectiveBytes(d))
+ok('effective capacity is monotonic increasing 17->22', caps.every((v, i) => i === 0 || v > caps[i - 1]), caps.map(mb).join(' < '))
+
+// capacityBreakpoints table (the numbers CLAUDE.md's depth 19-24 table uses)
+const bp = B.capacityBreakpoints.ENCRYPTION_OFF[0]
+const eff = d => bp.find(x => x.batchDepth === d)?.effectiveVolume
+ok('capacityBreakpoints depth 20 ~ 680 MB', /6\d\d.* MB/.test(eff(20) || ''), eff(20))
+ok('capacityBreakpoints depth 22 ~ 7.7 GB', /7\.\d+ GB/.test(eff(22) || ''), eff(22))
+
+// --- exports used across examples ---
+for (const x of ['Bee', 'Size', 'Duration', 'Topic', 'PrivateKey', 'PublicKey', 'EthAddress', 'NULL_IDENTIFIER']) ok(`export ${x} exists`, typeof B[x] !== 'undefined')
+
+// --- #27: ACT — getNodeAddresses (publisher key source) + Optional unwrap ---
+ok('Bee.getNodeAddresses exists (source of publisher PublicKey)', typeof B.Bee.prototype.getNodeAddresses === 'function')
+
+// --- Bee methods the skills call (upload/download, stamps, ACT, feeds, messaging) ---
+const methods = ['uploadFile', 'downloadFile', 'uploadData', 'downloadData', 'uploadFiles', 'uploadFilesFromDirectory', 'buyStorage', 'createPostageBatch', 'topUpBatch', 'diluteBatch', 'getPostageBatches', 'createGrantees', 'getGrantees', 'patchGrantees', 'gsocMine', 'gsocSend', 'gsocSubscribe', 'pssSend', 'pssSubscribe', 'pssReceive', 'makeFeedWriter', 'makeFeedReader', 'createFeedManifest', 'isConnected']
+for (const m of methods) ok(`Bee.${m} exists`, typeof B.Bee.prototype[m] === 'function')
+
+// --- #28: onClose is a REQUIRED field on the subscribe handler types ---
+try {
+  const dts = readFileSync(join(PKG, 'dist/types/types/index.d.ts'), 'utf8')
+  ok('subscribe handler types declare onClose as required (no `?`)', /onClose:\s*\(/.test(dts) && !/onClose\?:/.test(dts))
+} catch (e) {
+  ok('read handler .d.ts for onClose', false, e.message)
+}
+
+// --- #27: Optional (cafe-utility) unwraps via getOrThrow() and .value ---
+try {
+  const cafe = await import('cafe-utility')
+  const opt = cafe.Optional?.of?.('x')
+  ok('Optional.getOrThrow() unwraps (used for historyAddress)', !!opt && typeof opt.getOrThrow === 'function' && opt.getOrThrow() === 'x')
+  ok('Optional exposes .value (alternate unwrap)', !!opt && 'value' in opt && opt.value === 'x')
+} catch (e) {
+  ok('cafe-utility Optional import', false, e.message)
+}
+
+console.log(`\n# ${pass} passed, ${fail} failed\n`)
+process.exit(fail ? 1 : 0)


### PR DESCRIPTION
Fixes the E2E findings (#24–#31), re-verified against **installed bee-js 12.2.1 and swarm-cli 3.2.0** rather than the bee-js 8.x the issues were filed against.

## Changes
- **#31 setup-bee:** add "Step 0: Install Prerequisites" (curl/Node/npm for Ubuntu + macOS)
- **#29.1:** non-root `sudo env TAG=… bash` install note
- **#29.2:** 503 "syncing" ~30s startup-window note
- **#24:** keep `xdai.fairdatasociety.org` default (archival), document 429 fallback to `rpc.gnosischain.com` + `--json-rpc-url`
- **#29.5:** chainsync shows `Δ`, never "synchronized" (Δ<10 ≈ synced)
- **#25:** depth-17 capacity corrected to ~40 KB (old "7 MB" was depth 18); budget warning + affordable suggested stamp; added depth 18
- **#29.6:** compute amount from live `currentPrice`; static amounts marked as ~40% upper bounds
- **#26:** bee-js stamp helpers moved to `Utils.*`; 4 were **renamed** (`getDepthForSize`, `getAmountForDuration`, `getStampDuration`, `getStampTheoreticalBytes`), not removed
- **#30 troubleshoot:** error table — 400 = missing header, 404 = content or stamp-not-found; 402 not returned in practice
- **#27 act:** unwrap `historyAddress` Optional via `getOrThrow()`; pass `PublicKey` object from `getNodeAddresses()`; note swarm-cli `--act` 404 quirk
- **#28 messaging:** add required `onClose` to pss/gsoc subscribe examples
- **#29.3/.4 feed/host-website:** `--password` (or `--only-keypair`) on `identity create` and `feed print`
- **CLAUDE.md:** bump verified-against versions + bee-js `Utils` note

## Verification
Installed bee-js 12.2.1 + swarm-cli 3.2.0 and confirmed: `Utils.*` exports & renames, `historyAddress: Optional<Reference>`, `onClose` required, `getStampEffectiveBytes(17)=40890`, swarm-cli `identity create`/`feed print` `--password`/`--only-keypair` flags.

Note: bee-js 12.x targets Bee 2.7.0, so pairing with Bee 2.8.0 prints a non-fatal version-mismatch warning (documented in setup-bee).