### PR TITLE
#32 (partial): richer descriptions + progressive disclosure (no consolidation/MCP)

### DIFF
--- a/.claude/skills/act/SKILL.md
+++ b/.claude/skills/act/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: act
-description: Encrypt data on Swarm with per-account access control (ACT)
+description: Encrypt data on Swarm and control who can read it with ACT (Access Control Trie) — per-account access via Ethereum public keys, grantee lists, and add/revoke of access, using bee-js or swarm-cli. Use for private files, paid or subscriber-only content, or team-restricted data where only authorized accounts can decrypt.
 user-invocable: true
 ---
 

--- a/.claude/skills/build-app/SKILL.md
+++ b/.claude/skills/build-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-app
-description: Scaffold and build a dApp using Swarm for decentralized storage
+description: Scaffold a new Swarm dApp with create-swarm-app or add the bee-js SDK to an existing project (Node.js, TypeScript, or React/Vite). Covers connecting to Bee, upload/download patterns, auto-finding a postage stamp, and node-mode feature compatibility. Use when the user wants to start coding against Swarm or integrate bee-js into an app.
 user-invocable: true
 ---
 

--- a/.claude/skills/feed/SKILL.md
+++ b/.claude/skills/feed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feed
-description: Create and use feeds for dynamic content with stable addresses on Swarm
+description: Create and update feeds — a stable Swarm address (owner + topic) that always resolves to the latest content even as the underlying hash changes. Covers feed writers/readers, manifests for permanent URLs, and updates via bee-js or swarm-cli. Use for dynamic or updateable content: websites, blogs, app state, RSS/podcasts, social feeds.
 user-invocable: true
 ---
 

--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: help
-description: Swarm skills overview and routing to the right skill
+description: Swarm overview and entry point — checks whether a Bee node is running and routes the developer to the right Swarm skill. Use at the start of any Swarm task, when the user is unsure where to begin, or asks what they can build with Swarm, Bee, or bee-js.
 user-invocable: true
 ---
 

--- a/.claude/skills/host-website/SKILL.md
+++ b/.claude/skills/host-website/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: host-website
-description: Deploy a static website to Swarm with optional ENS
+description: Deploy a static website (a folder with index.html) to Swarm via swarm-cli or bee-js, as a one-time upload or an updateable feed, with optional ENS content-hash setup (eth.limo / bzz.link). Use when the user wants to publish, host, or update a site or single-page app on decentralized storage.
 user-invocable: true
 ---
 

--- a/.claude/skills/messaging/SKILL.md
+++ b/.claude/skills/messaging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: messaging
-description: Set up real-time messaging on Swarm using GSOC or PSS
+description: Set up real-time messaging on Swarm with GSOC (many-to-one, e.g. chat or notifications) or PSS (point-to-point, optionally encrypted, offline-capable), via bee-js. Covers mining keys, sending, subscribing, full-node requirements, and mutable-stamp needs. Use for chat, notifications, webhooks, or private peer-to-peer messages.
 user-invocable: true
 ---
 

--- a/.claude/skills/setup-bee/SKILL.md
+++ b/.claude/skills/setup-bee/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-bee
-description: Install and run a Bee light node for Swarm development
+description: Install and run a Bee light node for Swarm development on Linux/macOS — system prerequisites (Node.js, curl), Bee and swarm-cli install, funding the node (gift code or xDAI/xBZZ on Gnosis Chain), upgrading ultra-light to light, and buying a first postage stamp. Use when the user has no node, gets connection-refused on localhost:1633, or needs to start or fund Bee.
 user-invocable: true
 ---
 

--- a/.claude/skills/stamps/REFERENCE.md
+++ b/.claude/skills/stamps/REFERENCE.md
@@ -1,0 +1,98 @@
+# Postage Stamps — Reference
+
+Detailed reference for stamp management beyond the buy/size happy path in `SKILL.md`. Load this when the user needs the bee-js utility helpers, wants to manage an existing stamp (top up, dilute, inspect), or needs to check content retrievability.
+
+## bee-js Utility Functions
+
+All stamp helpers live under the `Utils` namespace in bee-js 12.x — they are **not** top-level exports. (Several were renamed from earlier versions; the old names below no longer exist.)
+
+```javascript
+import { Utils, Size, Duration } from '@ethersphere/bee-js'
+
+Utils.getDepthForSize(Size.fromMegabytes(100))        // Size → minimum depth (was getDepthForCapacity)
+Utils.getStampEffectiveBytes(depth)                   // depth → effective storable bytes
+Utils.getStampTheoreticalBytes(depth)                 // depth → max theoretical bytes (was getStampMaximumCapacityBytes)
+Utils.getStampCost(depth, amount)                     // depth + amount → cost (BZZ object)
+Utils.getStampUsage(utilization, depth, bucketDepth)  // how full a stamp is
+Utils.getStampDuration(amount, pricePerBlock, blockTime)   // amount → Duration (was getStampTtlSeconds)
+Utils.getAmountForDuration(Duration.fromDays(30), pricePerBlock, blockTime)  // Duration → amount (was getAmountForTtl)
+```
+
+`pricePerBlock` is the network's `currentPrice` (from `GET /chainstate`); `blockTime` is `5` seconds on Gnosis Chain.
+
+## Manage Stamps
+
+### List all stamps
+
+```bash
+swarm-cli stamp list
+```
+
+Or via API:
+
+```bash
+curl -s http://localhost:1633/stamps | jq
+```
+
+### Check a specific stamp
+
+```bash
+swarm-cli stamp show <stamp-id>
+```
+
+### Top up (extend duration)
+
+```bash
+swarm-cli stamp topup --stamp <stamp-id> --amount <additional-amount>
+```
+
+Via API:
+
+```bash
+curl -X PATCH "http://localhost:1633/stamps/topup/<batchID>/<amount>"
+```
+
+Via bee-js:
+
+```javascript
+await bee.topUpBatch(batchId, '40053139205')
+```
+
+### Dilute (increase capacity)
+
+Increase depth to store more data. Dilution alone decreases TTL — combine with topup to maintain duration.
+
+```bash
+swarm-cli stamp dilute --depth <new-depth> --stamp <stamp-id>
+```
+
+Via API:
+
+```bash
+curl -s -X PATCH http://localhost:1633/stamps/dilute/<batchID>/<newDepth>
+```
+
+Via bee-js:
+
+```javascript
+await bee.diluteBatch(batchId, 24)
+```
+
+## Check Content Retrievability
+
+```bash
+curl "http://localhost:1633/stewardship/<reference>"
+```
+
+Returns `isRetrievable: true/false`. If false and content is pinned locally:
+
+```bash
+curl -X PUT "http://localhost:1633/stewardship/<reference>"
+```
+
+## Reference
+
+- Stamp batches: https://docs.ethswarm.org/docs/develop/tools-and-features/buy-a-stamp-batch
+- bee-js docs: https://bee-js.ethswarm.org/docs/
+- Bee API: https://docs.ethswarm.org/api/
+- swarm-cli: https://github.com/ethersphere/swarm-cli

--- a/.claude/skills/stamps/SKILL.md
+++ b/.claude/skills/stamps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stamps
-description: List, buy, size, top up, and manage postage stamps for Swarm uploads
+description: List, buy, size, top up, and dilute postage stamps (postage batches) — required before any Swarm upload. Covers depth vs. capacity, amount vs. duration/TTL, mutable vs. immutable, live-price cost estimation, and the bee-js Utils stamp helpers. Use when the user needs a stamp, asks about storage cost/capacity/expiry, or hits a 'no usable stamp' error.
 user-invocable: true
 ---
 
@@ -20,7 +20,7 @@ If the command fails (connection refused, etc.), the node is not running — rou
 
 Present the results as a table with: batch ID (shortened), depth, effective capacity, type (mutable/immutable from `immutableFlag`), and approximate TTL in days (batchTTL / 86400).
 
-If they have a usable stamp with enough capacity and TTL, ask if they want to reuse it instead of buying a new one. They can also top up or dilute an existing stamp (see Manage Stamps below).
+If they have a usable stamp with enough capacity and TTL, ask if they want to reuse it instead of buying a new one. They can also top up or dilute an existing stamp (see [REFERENCE.md](REFERENCE.md)).
 
 ## What to Ask
 
@@ -167,97 +167,17 @@ const batchId = await bee.createPostageBatch('120159417615', 22)
 
 **Important:** Wait several minutes after purchase for the stamp to propagate on the network before using it.
 
-## bee-js Utility Functions
-
-All stamp helpers live under the `Utils` namespace in bee-js 12.x — they are **not** top-level exports. (Several were renamed from earlier versions; the old names below no longer exist.)
-
-```javascript
-import { Utils, Size, Duration } from '@ethersphere/bee-js'
-
-Utils.getDepthForSize(Size.fromMegabytes(100))        // Size → minimum depth (was getDepthForCapacity)
-Utils.getStampEffectiveBytes(depth)                   // depth → effective storable bytes
-Utils.getStampTheoreticalBytes(depth)                 // depth → max theoretical bytes (was getStampMaximumCapacityBytes)
-Utils.getStampCost(depth, amount)                     // depth + amount → cost (BZZ object)
-Utils.getStampUsage(utilization, depth, bucketDepth)  // how full a stamp is
-Utils.getStampDuration(amount, pricePerBlock, blockTime)   // amount → Duration (was getStampTtlSeconds)
-Utils.getAmountForDuration(Duration.fromDays(30), pricePerBlock, blockTime)  // Duration → amount (was getAmountForTtl)
-```
-
-`pricePerBlock` is the network's `currentPrice` (from `GET /chainstate`); `blockTime` is `5` seconds on Gnosis Chain.
-
-## Manage Stamps
-
-### List all stamps
-
-```bash
-swarm-cli stamp list
-```
-
-Or via API:
-
-```bash
-curl -s http://localhost:1633/stamps | jq
-```
-
-### Check a specific stamp
-
-```bash
-swarm-cli stamp show <stamp-id>
-```
-
-### Top up (extend duration)
-
-```bash
-swarm-cli stamp topup --stamp <stamp-id> --amount <additional-amount>
-```
-
-Via API:
-
-```bash
-curl -X PATCH "http://localhost:1633/stamps/topup/<batchID>/<amount>"
-```
-
-Via bee-js:
-
-```javascript
-await bee.topUpBatch(batchId, '40053139205')
-```
-
-### Dilute (increase capacity)
-
-Increase depth to store more data. Dilution alone decreases TTL — combine with topup to maintain duration.
-
-```bash
-swarm-cli stamp dilute --depth <new-depth> --stamp <stamp-id>
-```
-
-Via API:
-
-```bash
-curl -s -X PATCH http://localhost:1633/stamps/dilute/<batchID>/<newDepth>
-```
-
-Via bee-js:
-
-```javascript
-await bee.diluteBatch(batchId, 24)
-```
-
 ## TTL Warning
 
 TTL is estimated based on current storage price, which fluctuates as Swarm adoption changes. Always maintain a buffer for important data. Content with expired stamps cannot be re-uploaded unless pinned locally.
 
-## Check Content Retrievability
+## Managing an Existing Stamp
 
-```bash
-curl "http://localhost:1633/stewardship/<reference>"
-```
+For deeper operations, see **[REFERENCE.md](REFERENCE.md)**:
 
-Returns `isRetrievable: true/false`. If false and content is pinned locally:
-
-```bash
-curl -X PUT "http://localhost:1633/stewardship/<reference>"
-```
+- **bee-js utility functions** — `Utils.getStampCost`, `getStampEffectiveBytes`, `getDepthForSize`, `getAmountForDuration`, etc.
+- **Manage stamps** — list, inspect (`stamp show`), top up (extend duration), dilute (increase capacity)
+- **Check content retrievability** — `/stewardship/<reference>`
 
 ## Reference
 

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: troubleshoot
-description: Diagnose and fix common Bee node, connectivity, and upload issues
+description: Diagnose and fix common Bee node, connectivity, sync, funding, stamp, and upload/download problems — an ordered triage from 'is the node running?' through peers, chain sync, wallet balance, stamp validity, and Bee API error codes (400/404/422/500/503). Use when something on Swarm is failing, erroring out, or won't connect.
 user-invocable: true
 ---
 

--- a/.claude/skills/upload-download/SKILL.md
+++ b/.claude/skills/upload-download/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upload-download
-description: Upload and download data, files, or directories on Swarm
+description: Upload and download data, files, directories, and collections on Swarm via bee-js, swarm-cli, or the Bee HTTP API (/bytes and /bzz), in Node.js or the browser. Covers references, content types, and retrieval by hash. Use when the user wants to store or retrieve content and already has a running node and a postage stamp.
 user-invocable: true
 ---
 
@@ -203,7 +203,8 @@ Headers for upload:
 | "stamp not usable" | Stamp hasn't propagated yet — wait 2-3 minutes after buying |
 | "insufficient funds" | Wallet needs xBZZ — see `/setup-bee` funding section |
 | Connection refused | Node isn't running — route to `/setup-bee` |
-| 402 response | No usable stamp — route to `/stamps` |
+| 400 "invalid header params" | Missing/malformed `Swarm-Postage-Batch-Id` header — check the stamp header |
+| 404 "batch with id not found" | Invalid/unknown stamp ID, or no usable stamp — route to `/stamps` |
 | "not found" on download | Content may have expired, or reference is wrong |
 | Other errors | Route to `/troubleshoot` |
 


### PR DESCRIPTION
Addresses the parts of #32 the project endorses, **without** the 10→4 consolidation or MCP-first rewrite (both intentionally out of scope, per discussion on #32 and the direction of the `swarm-quickstart-skills` fork).

> Stacked on #37 — base branch is `fix/e2e-issues-24-31-beejs12`. Merge #37 first; GitHub will auto-retarget this to `main`.

## Changes
- **Richer descriptions on all 10 skills** — rewritten to be dual-purpose (what it does + when to use it + key terms) for reliable agent/registry discovery, kept ~2 sentences so they stay readable for humans. Pure frontmatter; no change to any skill's steps.
- **Progressive-disclosure exemplar on `stamps`** (the longest file) — moved bee-js `Utils` helpers, stamp management (topup/dilute/show), and retrievability into `stamps/REFERENCE.md`, loaded on demand. `SKILL.md` 268 → 187 lines; the common path (list → decide → buy) stays inline.
- **upload-download:** replaced a stale "402 response" error row with the actual 400/404 behavior (consistent with the #30 fix).

## What's intentionally NOT here
- **No 10→4 consolidation** — skills stay granular/self-contained.
- **No MCP-first rewrite** — the only behavioral change in #32; deferred for a separate decision.
- **No blanket REFERENCE.md split** — no other skill exceeds the ~500-line progressive-disclosure threshold, so splitting them would add the "REFERENCE not loaded" risk for little gain. `stamps` is offered as the pattern to apply selectively.

Refs #32.