### PR TITLE
Prototype: narrated node/stamp checks in /upload-download (evaluate before rollout)

### DIFF
--- a/.claude/skills/upload-download/SKILL.md
+++ b/.claude/skills/upload-download/SKILL.md
@@ -10,21 +10,23 @@ Guide a developer through uploading and downloading data on Swarm. Requires a ru
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now — **don't** just show the commands. **Narrate each one in a short line as you go** so the user can see what's happening, but **don't pause to ask permission**: these are read-only `GET`s to a local node. (Operations that cost xBZZ — buying or topping up a stamp — still require explicit confirmation; that rule is unchanged.)
 
-1. Node running?
+1. **Tell the user "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   - Reachable → confirm in one line, e.g. **"✓ Node is up (light mode)."**
+   - Fails / not reachable → **"✗ No Bee node running."** and route to `/setup-bee`.
 
-2. Stamp available?
+2. **Tell the user "Checking for a usable postage stamp…"**, then run:
    ```bash
    curl -s http://localhost:1633/stamps | jq '.stamps[] | select(.usable==true) | {batchID, depth, batchTTL}'
    ```
-   If no usable stamps → route to `/stamps`
+   - A usable stamp exists → **"✓ Found a usable stamp."** and proceed.
+   - None → **"✗ No usable stamp."** and route to `/stamps`.
 
-Present results briefly, then proceed.
+Keep each line to a few words. The point is transparency, not a confirmation gate — narrate, then continue.
 
 ## What to Ask
 


### PR DESCRIPTION
**Prototype — do not merge yet.** A "narrate, don't gate" middle ground for the auto-run probe behavior, on a single skill (`/upload-download`) so we can evaluate the feel before deciding whether to roll it out.

## What changes
The "Before Starting" node + stamp checks still run **automatically** (no confirmation prompt — they're read-only `GET`s to localhost), but the skill now **narrates each check in one short line**:

- "Checking your Bee node…" → "✓ Node is up (light mode)."
- "Checking for a usable postage stamp…" → "✓ Found a usable stamp."

## What does NOT change
- No confirmation gate added — flow stays frictionless.
- xBZZ-costing operations (buy / top-up / dilute) still require explicit confirmation, unchanged.
- Only `/upload-download` is touched; the other 9 skills keep the silent behavior pending a decision.

## Decision this informs
Whether to (a) keep silent everywhere, (b) adopt this narrated style across all probe-and-route skills, or (c) go further to confirm-first (the more educational, higher-friction option). See discussion under #32.