### PR TITLE
Narrate prerequisite checks across skills (silent-run + one-line status)

### DIFF
--- a/.claude/skills/act/SKILL.md
+++ b/.claude/skills/act/SKILL.md
@@ -10,21 +10,19 @@ Guide a developer through encrypting data on Swarm and controlling who can read 
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Node running?
+1. **Say "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   Reachable → "✓ Node is up (light mode)." | Fails → "✗ No Bee node running." and route to `/setup-bee`.
 
-2. Stamp available?
+2. **Say "Checking for a usable postage stamp…"**, then run:
    ```bash
    curl -s http://localhost:1633/stamps | jq '.stamps[] | select(.usable==true) | {batchID, depth, batchTTL}'
    ```
-   If no usable stamps → route to `/stamps`
-
-Present results briefly, then proceed.
+   Found → "✓ Found a usable stamp." and proceed. | None → "✗ No usable stamp." and route to `/stamps`.
 
 ## What to Ask
 

--- a/.claude/skills/build-app/SKILL.md
+++ b/.claude/skills/build-app/SKILL.md
@@ -10,20 +10,20 @@ Guide a developer through scaffolding and building an app that uses Swarm for de
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Node running?
+1. **Say "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   Reachable → "✓ Node is up (light mode)." | Fails → "✗ No Bee node running." and route to `/setup-bee`.
 
-2. Existing project?
+2. **Say "Checking for an existing project here…"**, then run:
    ```bash
    ls package.json 2>/dev/null && echo "EXISTING_PROJECT" || echo "NEW_PROJECT"
    ```
-   - **If `package.json` exists:** Default to Option B (add bee-js). Ask: "I see you already have a project here. Want me to add bee-js to it, or scaffold a separate Swarm project?"
-   - **If no project:** Default to Option A (scaffold). Ask what type.
+   - **If `package.json` exists:** "✓ Found an existing project." Default to Option B (add bee-js). Ask: "Want me to add bee-js to it, or scaffold a separate Swarm project?"
+   - **If no project:** "✗ No project here yet." Default to Option A (scaffold). Ask what type.
 
 ## What to Ask
 

--- a/.claude/skills/feed/SKILL.md
+++ b/.claude/skills/feed/SKILL.md
@@ -10,26 +10,25 @@ Guide a developer through creating and using feeds on Swarm. Feeds provide a sta
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Node running?
+1. **Say "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   Reachable → "✓ Node is up (light mode)." | Fails → "✗ No Bee node running." and route to `/setup-bee`.
 
-2. Stamp available?
+2. **Say "Checking for a usable postage stamp…"**, then run:
    ```bash
    curl -s http://localhost:1633/stamps | jq '.stamps[] | select(.usable==true) | {batchID, depth, batchTTL}'
    ```
-   If no usable stamps → route to `/stamps`
+   Found → "✓ Found a usable stamp." and proceed. | None → "✗ No usable stamp." and route to `/stamps`.
 
-3. Existing identities/feeds?
+3. **Say "Checking for existing publisher identities…"**, then run:
    ```bash
    swarm-cli identity list 2>/dev/null
    ```
-
-Present results briefly. If the developer already has an identity and feed, skip to [Update the feed](#update-the-feed) below.
+   Report what you find in one line. If the developer already has an identity and feed, skip to [Update the feed](#update-the-feed) below.
 
 ## What to Ask
 

--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -10,13 +10,13 @@ When a developer starts a conversation about building on Swarm, give them a quic
 
 ## Before Showing the Menu (run immediately)
 
-**Silently check node status — do not just show the command to the user:**
+**Say "Checking your Bee node…"**, then run this (don't just show the command; don't pause for confirmation — it's a read-only check):
 
 ```bash
 curl -s http://localhost:1633/status | jq .beeMode
 ```
 
-- **If the node is not running:** Open with "It looks like you don't have a Bee node running yet." Show the menu, but suggest starting with `/setup-bee`.
+- **If the node is not running:** "✗ No Bee node running yet." Open with "It looks like you don't have a Bee node running yet." Show the menu, but suggest starting with `/setup-bee`.
 - **If ultra-light:** Note that uploads won't work yet. Suggest upgrading via `/setup-bee`.
 - **If light/full and running:** Show the menu and ask what they want to build.
 

--- a/.claude/skills/host-website/SKILL.md
+++ b/.claude/skills/host-website/SKILL.md
@@ -10,21 +10,19 @@ Guide a developer through hosting a static website on Swarm. Ask which method th
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Node running?
+1. **Say "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   Reachable → "✓ Node is up (light mode)." | Fails → "✗ No Bee node running." and route to `/setup-bee`.
 
-2. Stamp available?
+2. **Say "Checking for a usable postage stamp…"**, then run:
    ```bash
    curl -s http://localhost:1633/stamps | jq '.stamps[] | select(.usable==true) | {batchID, depth, batchTTL}'
    ```
-   If no usable stamps → route to `/stamps`
-
-Present results briefly, then proceed.
+   Found → "✓ Found a usable stamp." and proceed. | None → "✗ No usable stamp." and route to `/stamps`.
 
 ## Prerequisites
 

--- a/.claude/skills/messaging/SKILL.md
+++ b/.claude/skills/messaging/SKILL.md
@@ -10,21 +10,19 @@ Guide a developer through setting up real-time messaging on Swarm. Two protocols
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Node running?
+1. **Say "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   Reachable → "✓ Node is up (light mode)." | Fails → "✗ No Bee node running." and route to `/setup-bee`.
 
-2. Stamp available?
+2. **Say "Checking for a usable postage stamp…"**, then run:
    ```bash
    curl -s http://localhost:1633/stamps | jq '.stamps[] | select(.usable==true) | {batchID, depth, batchTTL}'
    ```
-   If no usable stamps → route to `/stamps`
-
-Present results briefly, then proceed.
+   Found → "✓ Found a usable stamp." and proceed. | None → "✗ No usable stamp." and route to `/stamps`.
 
 ## What to Ask
 

--- a/.claude/skills/setup-bee/SKILL.md
+++ b/.claude/skills/setup-bee/SKILL.md
@@ -10,9 +10,9 @@ Guide a developer through getting a Bee light node running so they can build on 
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Detect platform:
+1. **Say "Detecting your platform…"**, then run:
    ```bash
    uname -s
    ```
@@ -20,12 +20,11 @@ Guide a developer through getting a Bee light node running so they can build on 
    - **Darwin (macOS):** Use the install script (or Homebrew if available)
    - **Other / Windows:** Advise WSL2 first, then the Linux install path
 
-2. Fetch the latest Bee version tag:
+2. **Say "Fetching the latest Bee version…"**, then run:
    ```bash
    curl -s https://api.github.com/repos/ethersphere/bee/releases/latest | jq -r .tag_name
    ```
-
-Use this tag in the install command below (replace TAG value).
+   Report it in one line (e.g. "✓ Latest is v2.8.0.") and use this tag in the install command below (replace TAG value).
 
 ## Node Modes
 

--- a/.claude/skills/stamps/SKILL.md
+++ b/.claude/skills/stamps/SKILL.md
@@ -10,13 +10,13 @@ Guide a developer through listing, buying, sizing, topping up, and managing post
 
 ## Step 1: List Existing Stamps (DO THIS FIRST)
 
-**Immediately run this command** before doing anything else — do not just show it to the user:
+**Say "Checking your existing stamps…"**, then run this immediately (don't just show it; don't pause for confirmation — it's a read-only check):
 
 ```bash
 curl -s http://localhost:1633/stamps | jq '.stamps[] | {batchID, depth, usable, batchTTL, immutableFlag}'
 ```
 
-If the command fails (connection refused, etc.), the node is not running — route to `/setup-bee`.
+If the command fails (connection refused, etc.), the node isn't running — say "✗ No Bee node running." and route to `/setup-bee`.
 
 Present the results as a table with: batch ID (shortened), depth, effective capacity, type (mutable/immutable from `immutableFlag`), and approximate TTL in days (batchTTL / 86400).
 

--- a/.claude/skills/upload-download/SKILL.md
+++ b/.claude/skills/upload-download/SKILL.md
@@ -10,21 +10,19 @@ Guide a developer through uploading and downloading data on Swarm. Requires a ru
 
 ## Before Starting (run immediately)
 
-**Run these checks now — do not just show the commands to the user:**
+Run these checks now and **narrate each one in a short line** — say what you're checking, run it (don't paste the command), then report the result. Don't pause for confirmation; these are read-only checks.
 
-1. Node running?
+1. **Say "Checking your Bee node…"**, then run:
    ```bash
    curl -s http://localhost:1633/status | jq .beeMode
    ```
-   If this fails → route to `/setup-bee`
+   Reachable → "✓ Node is up (light mode)." | Fails → "✗ No Bee node running." and route to `/setup-bee`.
 
-2. Stamp available?
+2. **Say "Checking for a usable postage stamp…"**, then run:
    ```bash
    curl -s http://localhost:1633/stamps | jq '.stamps[] | select(.usable==true) | {batchID, depth, batchTTL}'
    ```
-   If no usable stamps → route to `/stamps`
-
-Present results briefly, then proceed.
+   Found → "✓ Found a usable stamp." and proceed. | None → "✗ No usable stamp." and route to `/stamps`.
 
 ## What to Ask
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Skills live in `.claude/skills/`. Each skill is a directory containing a `SKILL.
 - Each skill is standalone — it should contain everything needed for that topic.
 - Skills should always check prerequisites (node running? stamp exists?) and route to the appropriate skill if not.
 - When referencing other skills, use the `/skill-name` format.
+- **Narrate prerequisite checks.** Skills run their prerequisite probes (node status, stamp availability, identities) automatically — never make the user confirm read-only localhost checks. But narrate each probe in one short line so the auto-run commands are legible: before, say what you're checking ("Checking your Bee node…"); after, report the result in a few words with ✓/✗ ("✓ Node is up (light mode)." / "✗ No node running."). Keep lines terse and consistent; narrate then continue — no confirmation gate. (Operations that cost xBZZ — stamp buy/top-up/dilute — still require explicit confirmation; that's separate and unchanged.)
 - Code examples should cover both **bee-js** and **swarm-cli** where applicable.
 - Keep commands and code up to date with the latest Bee and bee-js versions.
 - Skills last verified against: **Bee 2.8.0**, **bee-js 12.x**, **swarm-cli 3.x**


### PR DESCRIPTION
Adopts the "narrate, don't gate" pattern for the auto-run node/stamp prerequisite probes, decided after comparing with the `swarm-quickstart-skills` fork and trying it live.

## What changes
Each skill still runs its prerequisite check **automatically** (no confirmation prompt — read-only localhost GETs), but now **narrates** it: a short "Checking your Bee node…" before, and a "✓ Node is up (light mode)." / "✗ No node running." after. Makes the auto-run commands legible for a human onboarding tool, with no added friction.

- **CLAUDE.md** — new "Narrate prerequisite checks" convention so every skill does it identically.
- **9 skills** updated at their Before-Starting / Step-1 probe: `help`, `setup-bee`, `stamps`, `upload-download`, `host-website`, `build-app`, `feed`, `act`, `messaging`.

## What does NOT change
- No confirmation gate added — flow stays frictionless.
- xBZZ-costing operations (buy / top-up / dilute) still require explicit confirmation.
- `troubleshoot` untouched — it already shows its diagnostic commands step by step.